### PR TITLE
VERIFY requisites and subtractions rules.

### DIFF
--- a/TEST_convertNums.cpp
+++ b/TEST_convertNums.cpp
@@ -39,9 +39,53 @@ TEST(ConvertNums, convert_toArabic) {
   EXPECT_EQ(9, c.convert_toArabic(romanNumeral_toConvert));
   romanNumeral_toConvert = "XI";
   EXPECT_EQ(11, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "XXIII";
+  EXPECT_EQ(23, c.convert_toArabic(romanNumeral_toConvert));
 
+  /*Casos de excecao*/
+  /*Caso de quatro algorismos repetidos
+   * I, X, C, M podem ser repetidos no maximo tres vezes*/
   romanNumeral_toConvert = "IIII";
-  EXPECT_EQ(-4, c.convert_toArabic(romanNumeral_toConvert));	/*TESTE que deve falhar*/
+  EXPECT_EQ(-4, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "XXXX";
+  EXPECT_EQ(-4, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "CCCC";
+  EXPECT_EQ(-4, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "MMMM";
+  EXPECT_EQ(-4, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "IIMMMM";
+  EXPECT_EQ(-4, c.convert_toArabic(romanNumeral_toConvert));
+
+  /*Caso de dois algorismos repetidos
+   * V, L, D nao podem ser repetidos*/
+  romanNumeral_toConvert = "VV";
+  EXPECT_EQ(-2, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "LL";
+  EXPECT_EQ(-2, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "DD";
+  EXPECT_EQ(-2, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "VDD";
+  EXPECT_EQ(-2, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "LDDX";
+  EXPECT_EQ(-2, c.convert_toArabic(romanNumeral_toConvert));
+
+  /*Caso das subtracoes
+   * I pode apenas ser subtraido de V e X
+   * X pode apenas ser subtraido de L e C
+   * C pode apenas ser subtraido de D e M
+   * V, L e D nao podem ser subtraidos de nenhum outro algorismo*/
+  romanNumeral_toConvert = "ILX";
+  EXPECT_EQ(-1, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "XDM";
+  EXPECT_EQ(-1, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "CXX";
+  EXPECT_EQ(-1, c.convert_toArabic(romanNumeral_toConvert));	//CASO DEVE FALHAR
+  romanNumeral_toConvert = "VXX";
+  EXPECT_EQ(-1, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "LCC";
+  EXPECT_EQ(-1, c.convert_toArabic(romanNumeral_toConvert));
+  romanNumeral_toConvert = "DMM";
+  EXPECT_EQ(-1, c.convert_toArabic(romanNumeral_toConvert));
 }
 
 

--- a/convertNums.cpp
+++ b/convertNums.cpp
@@ -28,6 +28,12 @@ int ConvertNums::convert_toArabic(string & romanNumeral_String){
 	int sum = 0;
 	char prev='%';
 
+	/*VERIFYING REQUISITES AND VALIDITY*/
+	if(VERIFY_ifFour(romanNumeral_String) == -4) return -4;
+	if(VERIFY_ifTwo(romanNumeral_String) == -2) return -2;
+	/*VERIFYING if the subtraction is valid*/
+	if(VERIFY_Subtraction(romanNumeral_String) == -1) return -1;
+
 	for(int i=(romanNumeral_String.length()-1); i>=0; i--){		 /*Avalia tamanho da String e percorre ela toda*/
 
 		if(getRomanEquivalentValue(romanNumeral_String[i])<sum && (romanNumeral_String[i]!=prev)){
@@ -37,24 +43,79 @@ int ConvertNums::convert_toArabic(string & romanNumeral_String){
 		else{
 			sum += getRomanEquivalentValue(romanNumeral_String[i]);
 			prev = romanNumeral_String[i];
-			if(VERIFY_ifFourI(romanNumeral_String) == -4) return -4;
+
+
 		}
 
 	}
 	return sum;
 }
 
-int ConvertNums::VERIFY_ifFourI(string & String_toVerify){
-	int i = 0;
+int ConvertNums::VERIFY_ifFour(string & String_toVerify){
+	for(int i=(String_toVerify.length()-1); i>=0; i--){
+		if(String_toVerify[(i)] == String_toVerify[i+1] &&
+				String_toVerify[i+1] == String_toVerify[(i+2)] &&
+				String_toVerify[(i+2)] == String_toVerify[(i+3)]){
 
-	if(String_toVerify[(i)] == String_toVerify[i+1] &&
-			String_toVerify[i+1] == String_toVerify[(i+2)] &&
-			String_toVerify[(i+2)] == String_toVerify[(i+3)]){
-
-		if(String_toVerify[i] == 'I') return -4;
-		else if(String_toVerify[i] == 'X') return -4;
-		else if(String_toVerify[i] == 'C') return -4;
-		else if(String_toVerify[i] == 'M') return -4;
+			if(String_toVerify[i] == 'I') return -4;
+			else if(String_toVerify[i] == 'X') return -4;
+			else if(String_toVerify[i] == 'C') return -4;
+			else if(String_toVerify[i] == 'M') return -4;
+		}
 	}
-		return 0;
+	return 0;
+}
+
+int ConvertNums::VERIFY_ifTwo(string & String_toVerify){
+	int stringLength = String_toVerify.length()-1;
+	for(int i = 0; i <= stringLength; i++){
+		if(String_toVerify[(i)] == String_toVerify[i+1]){
+
+			if(String_toVerify[i] == 'V') return -2;
+			else if(String_toVerify[i] == 'L') return -2;
+			else if(String_toVerify[i] == 'D') return -2;
+		}
+	}
+	return 0;
+}
+
+int ConvertNums::VERIFY_Subtraction(string & String_toVerify){
+	int stringLength = String_toVerify.length()-1;
+
+
+	for(int i = 0; i <= stringLength; i++){
+		if(getRomanEquivalentValue(String_toVerify[i]) < getRomanEquivalentValue(String_toVerify[(i + 1)])){
+			switch(String_toVerify[i]){
+			case 'I':
+				if(String_toVerify[(i + 1)] == 'V' || String_toVerify[(i + 1)] == 'X')
+					return 0;
+				else return -1;
+
+			case 'X':
+				if(String_toVerify[(i + 1)] == 'L' || String_toVerify[(i + 1)] == 'C')
+					return 0;
+				else return -1;
+
+			case 'C':
+				if(String_toVerify[(i + 1)] == 'D' || String_toVerify[(i + 1)] == 'M')
+					return 0;
+				else return -1;
+
+			case 'V':
+				return -1;
+
+			case 'L':
+				return -1;
+
+			case 'D':
+				return -1;
+
+			default:
+				return 0;
+			}
+		}
+		else return 0;
+	}
+
+	return 0;
 }

--- a/convertNums.hpp
+++ b/convertNums.hpp
@@ -10,18 +10,14 @@
 #include <string>
 using std::string;
 
-
-
-
 class ConvertNums {
   public:
     ConvertNums(){};
     int getRomanEquivalentValue(char  romanString);
     int convert_toArabic(string& romanNumeral_String);
-    int VERIFY_ifFourI(string & String_toVerify);
+    int VERIFY_ifFour(string & String_toVerify);
+    int VERIFY_ifTwo(string & String_toVerify);
+    int VERIFY_Subtraction(string & String_toVerify);
 };
-
-
-
 
 #endif /* CONVERTNUMS_HPP_ */


### PR DESCRIPTION
New function that verifies rules for subtraction and numerals formatting rules, such as:
->The symbols "I", "X", "C", and "M" can be repeated three times in succession, but no more. (They may appear more than three times if they appear non-sequentially, such as XXXIX.) "V", "L", and "D" can never be repeated.

->"I" can be subtracted from "V" and "X" only. "X" can be subtracted from "L" and "C" only. "C" can be subtracted from "D" and "M" only. "V", "L", and "D" can never be subtracted
